### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
       - '**'  # overridden below by the commit-message filter
   workflow_call:  # called by release.yml
 
+# Limit GITHUB_TOKEN to read-only access to repository contents.
+permissions:
+  contents: read
+
 # Each event-type may fire a separate run; avoid redundant concurrent runs on
 # the same ref by cancelling the older one.
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/jmhthethird/frog_automation/security/code-scanning/7](https://github.com/jmhthethird/frog_automation/security/code-scanning/7)

To fix the problem, add an explicit `permissions:` block that limits the `GITHUB_TOKEN` to the minimum needed. This workflow only reads repository contents and uploads artifacts; there are no steps that need to write to the repo or to issues/PRs. Therefore `contents: read` at the workflow level is an appropriate minimal configuration; it will apply to all jobs (currently just `test`) that don’t override it.

The best fix with no functional change is to insert a root-level `permissions:` block near the top of `.github/workflows/ci.yml`, alongside `name`, `on`, and `concurrency`. For example:

```yaml
permissions:
  contents: read
```

No additional imports or methods are required because this is a pure YAML configuration change in the workflow file. The rest of the job definition remains unchanged. This both satisfies CodeQL and codifies least-privilege behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
